### PR TITLE
Fixing error with specifying month and day of month

### DIFF
--- a/Sivaschenko/Utility/Cron/Expression.php
+++ b/Sivaschenko/Utility/Cron/Expression.php
@@ -119,10 +119,11 @@ class Expression implements ExpressionInterface
                 $verbalString = $part->getVerbalString();
                 if (!empty($verbalString)) {
                     $stringParts[] = $verbalString;
-                    $format .= ', %s';
                 }
             }
-
+            if (!empty($stringParts)) {
+                $format .= ', %s';
+            }
             return sprintf(
                 $format.'.',
                 $hour->getValue(),

--- a/Sivaschenko/Utility/Cron/Expression.php
+++ b/Sivaschenko/Utility/Cron/Expression.php
@@ -121,9 +121,11 @@ class Expression implements ExpressionInterface
                     $stringParts[] = $verbalString;
                 }
             }
+
             if (!empty($stringParts)) {
                 $format .= ', %s';
             }
+
             return sprintf(
                 $format.'.',
                 $hour->getValue(),

--- a/Sivaschenko/Utility/Cron/Test/ExpressionTest.php
+++ b/Sivaschenko/Utility/Cron/Test/ExpressionTest.php
@@ -148,6 +148,7 @@ class ExpressionTest extends TestCase
             ['5 4 * * *', 'At 04:05.'],
             ['5 4 8 * *', 'At 04:05, on 8th day of month.'],
             ['5 4 1 * *', 'At 04:05, on 1st day of month.'],
+            ['5 4 1 1 *', 'At 04:05, on 1st day of month, in January.'],
             ['* * * * *', 'At every minute.'],
             ['* * * * 1', 'At every minute, on Monday.'],
             ['* * * 1 *', 'At every minute, in January.'],


### PR DESCRIPTION
Also added a test which illustrates the bug

It looked to me like implode(", ", $stringParts) and $format .= ', %s' were trying to do the same thing two different ways.  Either way I was getting a sprintf error of "too many arguments", and my new code tests ok.